### PR TITLE
remove deprecated defaultOperator

### DIFF
--- a/projects/conf/managed-schema
+++ b/projects/conf/managed-schema
@@ -2,7 +2,6 @@
 <!-- Solr managed schema - automatically generated - DO NOT EDIT -->
 <schema name="example-data-driven-schema" version="1.6">
   <uniqueKey>id</uniqueKey>
-  <solrQueryParser defaultOperator="AND"/>
   <fieldType name="ancestor_path" class="solr.TextField">
     <analyzer type="index">
       <tokenizer class="solr.KeywordTokenizerFactory"/>


### PR DESCRIPTION
The [defaultOperator](https://stackoverflow.com/questions/45103002/solr-how-to-set-a-default-operator-in-solr-6-6) is deprecated and no longer supported. This PR removes it from solr project core. 

An alternative to it is to use a [query param instead](https://solr.apache.org/guide/8_1/the-standard-query-parser.html#standard-query-parser-parameters):
```
q.op
Specifies the default operator for query expressions, overriding the default operator specified in the Schema. Possible values are "AND" or "OR".
```